### PR TITLE
Fix accountless subscriptions. 

### DIFF
--- a/app/controllers/spree/chimpy/subscribers_controller.rb
+++ b/app/controllers/spree/chimpy/subscribers_controller.rb
@@ -2,8 +2,8 @@ class Spree::Chimpy::SubscribersController < ApplicationController
   respond_to :html
 
   def create
-    @subscriber = Spree::Chimpy::Subscriber.new(params[:subscriber])
-
+    @subscriber = Spree::Chimpy::Subscriber.where(email: params[:chimpy_subscriber][:email]).first_or_initialize
+    @subscriber.update_attributes(params[:chimpy_subscriber])
     if @subscriber.save
       Spree::Chimpy::Subscription.new(@subscriber).subscribe
       flash[:notice] = I18n.t("spree.chimpy.subscriber.success")


### PR DESCRIPTION
-  The namespace of the subscriber model was incorrect. 
-  Fixed use case where a subscriber already existed. Now we just update the attributes instead of show an error. 
