### PR TITLE
Remove unneeded exception

### DIFF
--- a/lib/spree_chimpy.rb
+++ b/lib/spree_chimpy.rb
@@ -81,10 +81,6 @@ module Spree::Chimpy
     event  = payload[:event].to_sym
     object = payload[:object] || payload[:class].constantize.find(payload[:id])
 
-    if !object
-      raise Error.new("Unable to locate a #{payload[:class]} with id #{payload[:id]}")
-    end
-
     case event
     when :order
       orders.sync(object)


### PR DESCRIPTION
This exception will never be raised. ActiveRecord's find method will raise an exception of no object can be found by raising ActiveRecord::RecordNotFound.
