### PR TITLE
Add missing fields for category_id and category_name in the mail_chimp API submission

### DIFF
--- a/lib/spree/chimpy/interface/orders.rb
+++ b/lib/spree/chimpy/interface/orders.rb
@@ -36,10 +36,9 @@ module Spree::Chimpy
 
         items = order.line_items.map do |line|
           variant = line.variant
-          product = Spree::Product.find(variant.product_id)
-          ptaxonomy = Spree::Taxonomy.find_by_name("Categories")
-          taxon_id = product.taxons.where(:parent_id => ptaxonomy.id).uniq.map(&:id).first
-          taxon_name = product.taxons.where(:id => taxon_id).uniq.map(&:name).first
+          ptaxon = Spree::Taxonomy.find_by_name("Categories")
+          taxon_id = variant.product.taxons.where(:parent_id => ptaxon.id).uniq.map(&:id).first
+          taxon_name = variant.product.taxons.where(:id => taxon_id).uniq.map(&:name).first
 
           {product_id:    variant.id,
            sku:           variant.sku,


### PR DESCRIPTION
There may be cleaner ways to do this, but this does fix the issue of missing data in the API
call to ecomm_order_add().
