### PR TITLE
Fixing bug which occurs when a product is not associated with a taxon

### DIFF
--- a/lib/spree/chimpy/interface/orders.rb
+++ b/lib/spree/chimpy/interface/orders.rb
@@ -34,6 +34,9 @@ module Spree::Chimpy
           variant = line.variant
           taxon = variant.product.taxons.map(&:self_and_ancestors).flatten.uniq.detect { |t| t.parent == root_taxon }
 
+          # assign a default taxon if the product is not associated with a category
+          taxon = root_taxon if taxon.blank?
+
           {product_id:    variant.id,
            sku:           variant.sku,
            product_name:  variant.name,


### PR DESCRIPTION
If a product is not associated with a taxon the syncing process breaks without this fix.
