### PR TITLE
Add task to sync subscription status for existing users.

### DIFF
--- a/lib/tasks/spree_chimpy.rake
+++ b/lib/tasks/spree_chimpy.rake
@@ -43,4 +43,25 @@ namespace :spree_chimpy do
       end
     end
   end
+
+  desc 'sync all users with mailchimp'
+  task sync: :environment do
+    emails = Spree.user_class.pluck(:email)
+    puts "Syncing all users"
+    emails.each do |email|
+      response = Spree::Chimpy.list.info(email)
+      print '.'
+
+      response["errors"].try :each do |error|
+        puts "Error #{error["code"]} with email: #{error["email"]} \n msg: #{error["msg"]}"
+      end
+
+      case response[:status]
+      when "subscribed"
+        Spree.user_class.where(email: email).update_all(subscribed: true)
+      when "unsubscribed"
+        Spree.user_class.where(email: email).update_all(subscribed: false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
When installing this extension at a time, when users already signed up, i want to set the Spree::User#subscribed attributes corresponding to the mailchimp subscription list.
