### PR TITLE
Sidekiq fix. All (symbol) keys are cast to String in Redis. When process...

### DIFF
--- a/lib/spree/chimpy/workers/sidekiq.rb
+++ b/lib/spree/chimpy/workers/sidekiq.rb
@@ -9,7 +9,7 @@ module Spree::Chimpy
       end
 
       def perform(payload)
-        Spree::Chimpy.perform(payload)
+        Spree::Chimpy.perform(payload.with_indifferent_access)
       rescue Excon::Errors::Timeout, Excon::Errors::SocketError
         log "Mailchimp connection timeout reached, closing"
       end


### PR DESCRIPTION
...ing the payload, pass an indifferent access hash so it doesn't matter how the hash is accessed.