### PR TITLE
Do Not Mark Banned Users As Subscribed

### DIFF
--- a/lib/spree/chimpy/interface/list.rb
+++ b/lib/spree/chimpy/interface/list.rb
@@ -25,7 +25,7 @@ module Spree::Chimpy
           segment([email]) if options[:customer]
         rescue Mailchimp::ListInvalidImportError, Mailchimp::ValidationError => ex
           log "Subscriber #{email} rejected for reason: [#{ex.message}]"
-          true
+          self.user_rejected(email)
         end
       end
 
@@ -94,6 +94,11 @@ module Spree::Chimpy
 
       def segment_id
         @segment_id ||= find_segment_id
+      end
+
+      def user_rejected(email)
+        user = Spree::User.find_by(email: email)
+        user.update_attribute(:subscribed, false) if user
       end
     end
   end


### PR DESCRIPTION
If a user is rejected by MailChimp we should not mark them as subscribed
in the corresponding Spree Store