### PR TITLE
Banned subscribers are not catched

### DIFF
--- a/lib/spree/chimpy/interface/list.rb
+++ b/lib/spree/chimpy/interface/list.rb
@@ -25,7 +25,7 @@ module Spree::Chimpy
           segment([email]) if options[:customer]
         rescue Mailchimp::ListInvalidImportError, Mailchimp::ValidationError => ex
           log "Subscriber #{email} rejected for reason: [#{ex.message}]"
-          true
+          self.user_rejected(email)
         end
       end
 
@@ -94,6 +94,11 @@ module Spree::Chimpy
 
       def segment_id
         @segment_id ||= find_segment_id
+      end
+
+      def user_rejected(email)
+        user = Spree::User.find_by(email: email)
+        user.update_attribute(:subscribed, false) if user
       end
     end
   end

--- a/lib/spree/chimpy/interface/list.rb
+++ b/lib/spree/chimpy/interface/list.rb
@@ -25,7 +25,7 @@ module Spree::Chimpy
           segment([email]) if options[:customer]
         rescue Mailchimp::ListInvalidImportError, Mailchimp::ValidationError => ex
           log "Subscriber #{email} rejected for reason: [#{ex.message}]"
-          self.user_rejected(email)
+          fail Spree::Chimpy::EmailError, 'email unallowed subscription', caller
         end
       end
 
@@ -94,11 +94,6 @@ module Spree::Chimpy
 
       def segment_id
         @segment_id ||= find_segment_id
-      end
-
-      def user_rejected(email)
-        user = Spree::User.find_by(email: email)
-        user.update_attribute(:subscribed, false) if user
       end
     end
   end

--- a/lib/spree/chimpy/subscription.rb
+++ b/lib/spree/chimpy/subscription.rb
@@ -9,6 +9,8 @@ module Spree::Chimpy
     def subscribe
       return unless configured?
       defer(:subscribe) if subscribing?
+    rescue Spree::Chimpy::EmailError
+      unsubscribe_user
     end
 
     def unsubscribe
@@ -39,6 +41,10 @@ module Spree::Chimpy
 
     def unsubscribing?
       !@model.new_record? && !@model.subscribed && @model.subscribed_changed?
+    end
+
+    def unsubscribe_user
+      @model.update_column(:subscribed, false)
     end
 
     def merge_vars_changed?

--- a/lib/spree_chimpy.rb
+++ b/lib/spree_chimpy.rb
@@ -7,6 +7,7 @@ require 'coffee_script'
 
 module Spree::Chimpy
   extend self
+  class EmailError < StandardError; end
 
   def config(&block)
     yield(Spree::Chimpy::Config)

--- a/spec/lib/list_interface_spec.rb
+++ b/spec/lib/list_interface_spec.rb
@@ -25,7 +25,7 @@ describe Spree::Chimpy::Interface::List do
       expect(lists).to receive(:subscribe).
         with('a3d3', {email: 'user@example.com'},
               {}, 'html', true, true, true, true).and_raise Mailchimp::ListInvalidImportError
-      expect(lambda { interface.subscribe("user@example.com") }).not_to raise_error
+      expect(lambda { interface.subscribe("user@example.com") }).to raise_error(Spree::Chimpy::EmailError)
     end
   end
 

--- a/spec/lib/subscription_spec.rb
+++ b/spec/lib/subscription_spec.rb
@@ -139,6 +139,15 @@ describe Spree::Chimpy::Subscription do
       end
     end
 
+    context 'when adding a user that is not allowed' do
+      let(:user) { create(:user, subscribed: true) }
+
+      it 'rejects and unsubscribes the model' do
+        interface.stub(:subscribe).and_raise(Spree::Chimpy::EmailError)
+        expect(user.subscribed).to be false
+      end
+    end
+
     context "when updating a user and not changing subscription details" do
       it "does not update mailchimp" do
         interface.stub(:subscribe)

--- a/spec/lib/subscription_spec.rb
+++ b/spec/lib/subscription_spec.rb
@@ -28,7 +28,7 @@ describe Spree::Chimpy::Subscription do
       end
 
       it "subscribes users" do
-        interface.should_receive(:subscribe).with(user.email, {'SIZE' => '10', 'HEIGHT' => '20'}, customer: true)
+        expect(interface).to receive(:subscribe).with(user.email, {'SIZE' => '10', 'HEIGHT' => '20'}, customer: true)
         user.save
       end
     end
@@ -38,8 +38,8 @@ describe Spree::Chimpy::Subscription do
       let(:subscription) { described_class.new(subscriber) }
 
       it "subscribes subscribers" do
-        interface.should_receive(:subscribe).with(subscriber.email, {}, customer: false)
-        interface.should_not_receive(:segment)
+        expect(interface).to receive(:subscribe).with(subscriber.email, {}, customer: false)
+        expect(interface).to_not receive(:segment)
         subscriber.save
       end
     end
@@ -49,21 +49,21 @@ describe Spree::Chimpy::Subscription do
       let(:subscription) { double(:subscription) }
 
       before do
-        interface.should_receive(:subscribe).once.with(user.email)
+        allow(interface).to receive(:subscribe)
         user.stub(subscription: subscription)
       end
 
       context "when update needed" do
         it "calls resubscribe" do
-          subscription.should_receive(:resubscribe)
+          expect(subscription).to receive(:resubscribe)
           user.save
         end
       end
 
       context "when update not needed" do
         it "still calls resubscribe, and does nothing" do
-          subscription.should_receive(:resubscribe)
-          subscription.should_not_receive(:unsubscribe)
+          expect(subscription).to receive(:resubscribe)
+          expect(subscription).to_not receive(:unsubscribe)
           user.save
         end
       end
@@ -77,7 +77,7 @@ describe Spree::Chimpy::Subscription do
       context "subscribed user" do
         let(:user) { create(:user, subscribed: true) }
         it "unsubscribes" do
-          interface.should_receive(:unsubscribe).with(user.email)
+          expect(interface).to receive(:unsubscribe).with(user.email)
           user.subscribed = false
           subscription.unsubscribe
         end
@@ -86,7 +86,7 @@ describe Spree::Chimpy::Subscription do
       context "non-subscribed user" do
         let(:user) { build(:user, subscribed: false) }
         it "does nothing" do
-          interface.should_not_receive(:unsubscribe)
+          expect(interface).to_not receive(:unsubscribe)
           subscription.unsubscribe
         end
       end
@@ -98,7 +98,7 @@ describe Spree::Chimpy::Subscription do
 
       context "#resubscribe" do
         it "subscribes the user" do
-          interface.should_receive(:subscribe).with(user.email, {}, {customer: true})
+          expect(interface).to receive(:subscribe).with(user.email, {}, {customer: true})
           user.subscribed = true
           subscription.resubscribe
         end
@@ -113,7 +113,7 @@ describe Spree::Chimpy::Subscription do
 
       context "#resubscribe" do
         it "unsubscribes the user" do
-          interface.should_receive(:unsubscribe).with(user.email)
+          expect(interface).to receive(:unsubscribe).with(user.email)
           user.subscribed = false
           subscription.resubscribe
         end
@@ -132,7 +132,7 @@ describe Spree::Chimpy::Subscription do
           it "subscribes the user once again" do
             user.size += 5
             user.height += 10
-            interface.should_receive(:subscribe).with(user.email, {"SIZE"=> user.size.to_s, "HEIGHT"=> user.height.to_s}, {:customer=>true})
+            expect(interface).to receive(:subscribe).with(user.email, {"SIZE"=> user.size.to_s, "HEIGHT"=> user.height.to_s}, {:customer=>true})
             subscription.resubscribe
           end
         end
@@ -153,7 +153,7 @@ describe Spree::Chimpy::Subscription do
         interface.stub(:subscribe)
         user = create(:user, subscribed: true)
 
-        interface.should_not_receive(:subscribe)
+        expect(interface).to_not receive(:subscribe)
         user.spree_api_key = 'something'
         user.save!
       end


### PR DESCRIPTION
When we subscribe a subscriber, if Mailchimp returns an error saying that the email is banned, we still flag the Spree::User as subscribed.  
