### PR TITLE
Chimpy includes ControllerHelpers::Order helper everywhere

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,6 @@ gem 'spree_auth_devise', github: "spree/spree_auth_devise", branch: '2-3-stable'
 gem 'libnotify'
 gem 'fuubar'
 gem 'byebug'
+gem 'pry-byebug'
 
 gemspec

--- a/lib/spree/chimpy/controller_filters.rb
+++ b/lib/spree/chimpy/controller_filters.rb
@@ -2,23 +2,23 @@ module Spree::Chimpy
   module ControllerFilters
     extend ActiveSupport::Concern
 
-    included do |variable|
+    included do
       before_filter :find_mail_chimp_params
-      
       include ::Spree::Core::ControllerHelpers::Order
+    end
+
 
     private
-      def find_mail_chimp_params
-        mc_eid = params[:mc_eid] || session[:mc_eid]
-        mc_cid = params[:mc_cid] || session[:mc_cid]
-        if (mc_eid || mc_cid) && (session[:order_id] || params[:record_mc_details])
-          attributes = {campaign_id: mc_cid,
-                        email_id:    mc_eid}
-          if current_order(create_order_if_necessary: true).source
-            current_order.source.update_attributes(attributes)
-          else
-            current_order.create_source(attributes)
-          end
+    def find_mail_chimp_params
+      mc_eid = params[:mc_eid] || session[:mc_eid]
+      mc_cid = params[:mc_cid] || session[:mc_cid]
+      if (mc_eid || mc_cid) && (session[:order_id] || params[:record_mc_details])
+        attributes = {campaign_id: mc_cid,
+                      email_id:    mc_eid}
+        if current_order(create_order_if_necessary: true).source
+          current_order.source.update_attributes(attributes)
+        else
+          current_order.create_source(attributes)
         end
       end
     end

--- a/lib/spree/chimpy/controller_filters.rb
+++ b/lib/spree/chimpy/controller_filters.rb
@@ -3,11 +3,9 @@ module Spree::Chimpy
     extend ActiveSupport::Concern
 
     included do
-      include ::Spree::Core::ControllerHelpers::Order
-
       before_filter :set_mailchimp_params
       before_filter :find_mail_chimp_params, if: :mailchimp_params?
-      # before_filter :no_current_order, unless: :mailchimp_params?
+      include ::Spree::Core::ControllerHelpers::Order
     end
 
     private
@@ -24,12 +22,8 @@ module Spree::Chimpy
         (!session[:order_id].nil? || !params[:record_mc_details].nil?)
     end
 
-    # def no_current_order
-    #   send(:remove_method, :set_current_order)
-    # end
-
     def find_mail_chimp_params
-      attributes = {campaign_id: mc_cid, email_id: mc_eid}
+      attributes = { campaign_id: mc_cid, email_id: mc_eid }
       if current_order(create_order_if_necessary: true).source
         current_order.source.update_attributes(attributes)
       else

--- a/lib/spree/chimpy/controller_filters.rb
+++ b/lib/spree/chimpy/controller_filters.rb
@@ -3,13 +3,15 @@ module Spree::Chimpy
     extend ActiveSupport::Concern
 
     included do
-      before_filter :set_mailchimp_params
-      before_filter { |c| c.send(:find_mail_chimp_params) if c.send(:mailchimp_params?) }
       include ::Spree::Core::ControllerHelpers::Order
+
+      before_filter :set_mailchimp_params
+      before_filter :find_mail_chimp_params, if: :mailchimp_params?
+      # before_filter :no_current_order, unless: :mailchimp_params?
     end
 
-
     private
+
     attr_reader :mc_eid, :mc_cid
 
     def set_mailchimp_params
@@ -21,6 +23,10 @@ module Spree::Chimpy
       (!mc_eid.nil? || !mc_cid.nil?) &&
         (!session[:order_id].nil? || !params[:record_mc_details].nil?)
     end
+
+    # def no_current_order
+    #   send(:remove_method, :set_current_order)
+    # end
 
     def find_mail_chimp_params
       attributes = {campaign_id: mc_cid, email_id: mc_eid}

--- a/lib/spree/chimpy/controller_filters.rb
+++ b/lib/spree/chimpy/controller_filters.rb
@@ -3,23 +3,31 @@ module Spree::Chimpy
     extend ActiveSupport::Concern
 
     included do
-      before_filter :find_mail_chimp_params
+      before_filter :set_mailchimp_params
+      before_filter { |c| c.send(:find_mail_chimp_params) if c.send(:mailchimp_params?) }
       include ::Spree::Core::ControllerHelpers::Order
     end
 
 
     private
+    attr_reader :mc_eid, :mc_cid
+
+    def set_mailchimp_params
+      @mc_eid = params[:mc_eid] || session[:mc_eid]
+      @mc_cid = params[:mc_cid] || session[:mc_cid]
+    end
+
+    def mailchimp_params?
+      (!mc_eid.nil? || !mc_cid.nil?) &&
+        (!session[:order_id].nil? || !params[:record_mc_details].nil?)
+    end
+
     def find_mail_chimp_params
-      mc_eid = params[:mc_eid] || session[:mc_eid]
-      mc_cid = params[:mc_cid] || session[:mc_cid]
-      if (mc_eid || mc_cid) && (session[:order_id] || params[:record_mc_details])
-        attributes = {campaign_id: mc_cid,
-                      email_id:    mc_eid}
-        if current_order(create_order_if_necessary: true).source
-          current_order.source.update_attributes(attributes)
-        else
-          current_order.create_source(attributes)
-        end
+      attributes = {campaign_id: mc_cid, email_id: mc_eid}
+      if current_order(create_order_if_necessary: true).source
+        current_order.source.update_attributes(attributes)
+      else
+        current_order.create_source(attributes)
       end
     end
   end

--- a/spec/controllers/controller_filters_spec.rb
+++ b/spec/controllers/controller_filters_spec.rb
@@ -34,11 +34,4 @@ describe ::Spree::StoreController do
 
     get :index
   end
-
-  it 'skips the set_current_order filter if not needed' do
-    filter_list = subject._process_action_callbacks.map(&:filter)
-    expect(filter_list).to_not include(:set_curent_order)
-
-    get :index
-  end
 end

--- a/spec/controllers/controller_filters_spec.rb
+++ b/spec/controllers/controller_filters_spec.rb
@@ -36,9 +36,9 @@ describe ::Spree::StoreController do
   end
 
   it 'skips the set_current_order filter if not needed' do
-    expect(subject).to_not receive(:set_curent_order)
+    filter_list = subject._process_action_callbacks.map(&:filter)
+    expect(filter_list).to_not include(:set_curent_order)
 
     get :index
   end
-
 end

--- a/spec/controllers/controller_filters_spec.rb
+++ b/spec/controllers/controller_filters_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe ::Spree::StoreController do
+
+  before do
+    subject.session[:mc_eid] = '1234'
+    subject.session[:mc_cid] = 'abcd'
+  end
+
+  it 'sets the source attributes on order' do
+    binding.pry
+    get :index
+    expect(subject).to receive(:find_mail_chimp_params)
+  end
+
+end

--- a/spec/controllers/controller_filters_spec.rb
+++ b/spec/controllers/controller_filters_spec.rb
@@ -1,16 +1,44 @@
 require 'spec_helper'
 
 describe ::Spree::StoreController do
-
-  before do
-    subject.session[:mc_eid] = '1234'
-    subject.session[:mc_cid] = 'abcd'
+  controller(::Spree::StoreController) do
+    def index
+      head :ok
+    end
   end
 
-  it 'sets the source attributes on order' do
-    binding.pry
-    get :index
+  let(:user) { create(:user) }
+  subject { controller }
+
+  before do
+    allow(subject).to receive(:try_spree_current_user).and_return(user)
+    subject.session[:order_id] = 'R1919'
+  end
+
+  it 'sets the attributes for order if eid/cid is set in session' do
+    subject.session[:mc_eid] = '1234'
+    subject.session[:mc_cid] = 'abcd'
     expect(subject).to receive(:find_mail_chimp_params)
+
+    get :index
+  end
+
+  it 'sets the attributes for the order if eid/cid is set in the params' do
+    expect(subject).to receive(:find_mail_chimp_params)
+
+    get :index, mc_eid: '1234', mc_cid: 'abcd'
+  end
+
+  it 'does not call find mail chimp params method if no eid/cid' do
+    expect(subject).to_not receive(:find_mail_chimp_params)
+
+    get :index
+  end
+
+  it 'skips the set_current_order filter if not needed' do
+    expect(subject).to_not receive(:set_curent_order)
+
+    get :index
   end
 
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,7 +1,5 @@
 require 'spec_helper'
 
-class Spree::Adjustment::Adjustable; end
-
 describe Spree::Order do
   let(:key) { 'e025fd58df5b66ebd5a709d3fcf6e600-us8' }
   let(:order) { create(:completed_order_with_totals) }

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,16 +1,17 @@
 require 'spec_helper'
 
-describe Spree::Order do
+class Spree::Adjustment::Adjustable; end
 
+describe Spree::Order do
   let(:key) { 'e025fd58df5b66ebd5a709d3fcf6e600-us8' }
   let(:order) { create(:completed_order_with_totals) }
 
-  it "has a source" do
+  it 'has a source' do
     order = Spree::Order.new
     expect(order).to respond_to(:source)
   end
 
-  context "notifying mail chimp" do
+  context 'notifying mail chimp' do
     before do
       Spree::Chimpy::Config.key = nil
 
@@ -21,18 +22,18 @@ describe Spree::Order do
 
     subject { Spree::Chimpy }
 
-    it "doesnt update when order is not completed" do
+    it 'doesnt update when order is not completed' do
       expect(subject).to_not receive(:enqueue)
       @not_completed_order.update!
     end
 
-    it "updates when order is completed" do
+    it 'updates when order is completed' do
       new_order = create(:completed_order_with_pending_payment, state: 'confirm')
       expect(subject).to receive(:enqueue).with(:order, new_order)
       new_order.next
     end
 
-    it "sync when order is completed" do
+    it 'sync when order is completed' do
       expect(subject).to receive(:enqueue).with(:order, order)
       order.cancel!
     end

--- a/spree_chimpy.gemspec
+++ b/spree_chimpy.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'mailchimp-api', '~> 2.0.5'
 
   s.add_development_dependency 'rspec-rails', '~> 2.14'
+  s.add_development_dependency 'rubocop'
   s.add_development_dependency 'capybara', '~> 2.2.1'
   s.add_development_dependency 'poltergeist'
   s.add_development_dependency 'factory_girl', '~> 4.4'


### PR DESCRIPTION
https://github.com/DynamoMTL/spree_chimpy/blob/master/lib/spree/chimpy/controller_filters.rb#L8

Which causes `set_current_order` to be called before each request. 

@joshnuss @braidn Is this necessary?