### PR TITLE
When Creating Segment, Ensure Only ID is Returned

### DIFF
--- a/lib/spree/chimpy/interface/list.rb
+++ b/lib/spree/chimpy/interface/list.rb
@@ -82,7 +82,9 @@ module Spree::Chimpy
       def create_segment
         log "Creating segment #{@segment_name}"
 
-        @segment_id = api_call.static_segment_add(list_id, @segment_name)
+        segment = api_call.static_segment_add(list_id, @segment_name)
+        
+        @segment_id = segment['id']
       end
 
       def find_segment_id


### PR DESCRIPTION
`api_call.static_segment_add` returns a Hash, not the segment's ID, so when a segment is created, `@segment_id` can contain an unexpected Hash, which causes an exception to be thrown when, say, subscribing a customer. Bad news bears!