### PR TITLE
Skip Finding Segments If No Name Provided

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source 'https://rubygems.org'
 
 gem 'spree', github: 'spree/spree', branch: '2-3-stable'
 gem 'spree_auth_devise', github: "spree/spree_auth_devise", branch: '2-3-stable'
-gem 'libnotify'
-gem 'fuubar'
 gem 'byebug'
 gem 'pry-byebug'
 

--- a/lib/spree/chimpy/interface/list.rb
+++ b/lib/spree/chimpy/interface/list.rb
@@ -86,7 +86,7 @@ module Spree::Chimpy
       end
 
       def find_segment_id
-        segments = api_call.static_segments(list_id)
+        segments = api_call.static_segments(list_id, false) #get counts boolean set to false
         segment  = segments.detect {|segment| segment['name'].downcase == @segment_name.downcase }
 
         segment['id'] if segment

--- a/spec/features/spree/admin/subscription_spec.rb
+++ b/spec/features/spree/admin/subscription_spec.rb
@@ -9,6 +9,10 @@ feature 'Chimpy Admin', :js do
     visit spree.admin_path
   end
 
+  before :each do
+    Excon.defaults[:ssl_verify_peer] = false
+  end
+
   scenario 'new user subscription with subscription checked' do
     click_link 'Users'
     click_link 'New User'

--- a/spec/lib/list_interface_spec.rb
+++ b/spec/lib/list_interface_spec.rb
@@ -62,13 +62,13 @@ describe Spree::Chimpy::Interface::List do
     expect(lists).to receive(:subscribe).
       with('a3d3', {email: 'user@example.com'}, {'SIZE' => '10'},
             'html', true, true, true, true)
-    expect(lists).to receive(:static_segments).with('a3d3').and_return([{"id" => 123, "name" => "customers"}])
+    expect(lists).to receive(:static_segments).with('a3d3', false).and_return([{"id" => 123, "name" => "customers"}])
     expect(lists).to receive(:static_segment_members_add).with('a3d3', 123, [{:email => "user@example.com"}])
     interface.subscribe("user@example.com", {'SIZE' => '10'}, {customer: true})
   end
 
   it "segments" do
-    expect(lists).to receive(:static_segments).with('a3d3').and_return([{"id" => '123', "name" => "customers"}])
+    expect(lists).to receive(:static_segments).with('a3d3', false).and_return([{"id" => '123', "name" => "customers"}])
     expect(lists).to receive(:static_segment_members_add).with('a3d3', 123, [{email: "test@test.nl"}, {email: "test@test.com"}])
     interface.segment(["test@test.nl", "test@test.com"])
   end

--- a/spec/requests/subscribers_spec.rb
+++ b/spec/requests/subscribers_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 describe 'Subscribers' do
+  before :each do
+    Excon.defaults[:ssl_verify_peer] = false
+  end
 
   context 'with valid subscription' do
     it 'redirects to referer' do

--- a/spree_chimpy.gemspec
+++ b/spree_chimpy.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', '~> 2.1'
   s.add_dependency 'mailchimp-api', '~> 2.0.5'
 
-  s.add_development_dependency 'rspec-rails', '~> 2.14'
+  s.add_development_dependency 'rspec-rails', '~> 2.99'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'capybara', '~> 2.2.1'
   s.add_development_dependency 'poltergeist'


### PR DESCRIPTION
If the initializer doesn't pass a segment_name, stop the lookup
processes. This will save on time when people have many many segments
and the initializer has to look through all of them with the detect
method.