### PR TITLE
Add ability to make customer segment functionality optional on list

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ end
 By default spree_chimpy will try to segment customers. The segment name can be configured using the `segment_name` setting.
 Spree_chimpy will use an existing segment if it exists. If no segment can be found it will be created for you automatically.
 
+If you would like to not use the segmentation functionality, simply configure spree_chimpy to have a blank or nil customer_segment_name.
+
+```ruby
+Spree::Chimpy.config do |config|
+  config.customer_segment_name = ""
+end
+
+```
+
 #### Note about double-opt-in & segmenting
 
 Mailchimp does not allow you to segment emails that have not confirmed their subscription. This means that if you use the

--- a/lib/spree/chimpy/interface/list.rb
+++ b/lib/spree/chimpy/interface/list.rb
@@ -1,7 +1,7 @@
 module Spree::Chimpy
   module Interface
     class List
-      delegate :log, to: Spree::Chimpy
+      delegate :log, :segment_enabled?, to: Spree::Chimpy
 
       def initialize(list_name, segment_name, double_opt_in, send_welcome_email, list_id)
         @api           = Spree::Chimpy.api
@@ -73,6 +73,8 @@ module Spree::Chimpy
       end
 
       def segment(emails = [])
+        return unless segment_enabled?
+
         log "Adding #{emails} to segment #{@segment_name} [#{segment_id}] in list [#{list_id}]"
 
         params = emails.map { |email| { email: email } }

--- a/lib/spree_chimpy.rb
+++ b/lib/spree_chimpy.rb
@@ -49,6 +49,10 @@ module Spree::Chimpy
     list.list_id
   end
 
+  def segment_enabled?
+    !Config.customer_segment_name.blank?
+  end
+
   def segment_exists?
     list.segment_id
   end
@@ -88,7 +92,7 @@ module Spree::Chimpy
   end
 
   def ensure_segment
-    if list_exists? && !segment_exists?
+    if list_exists? && segment_enabled? && !segment_exists?
       create_segment
       Rails.logger.error("spree_chimpy: hmm.. a static segment named `#{Config.customer_segment_name}` was not found. Creating it now")
     end

--- a/spec/lib/chimpy_spec.rb
+++ b/spec/lib/chimpy_spec.rb
@@ -63,6 +63,41 @@ describe Spree::Chimpy do
     end
   end
 
+  describe "segment_enabled?" do
+    it "is true when a segment name is configured" do
+      Spree::Chimpy::Config.customer_segment_name = "example"
+      expect(Spree::Chimpy.segment_enabled?).to eq true
+    end
+
+    it "is false when segment name is blank or nil" do
+      [nil, ""].each do |val|
+        Spree::Chimpy::Config.customer_segment_name = val
+        expect(Spree::Chimpy.segment_enabled?).to eq false
+      end
+    end
+  end
+
+  describe "ensure_segment" do
+    before(:each) do
+      allow(Spree::Chimpy).to receive(:list_exists?) { true }
+    end
+
+    it "does not create the segment when not enabled" do
+      allow(Spree::Chimpy).to receive(:segment_enabled?) { false }
+      expect(Spree::Chimpy).to_not receive(:create_segment)
+
+      Spree::Chimpy.ensure_segment
+    end
+
+    it "creates a segment when enabled" do
+      allow(Spree::Chimpy).to receive(:segment_enabled?) { true }
+      allow(Spree::Chimpy).to receive(:segment_exists?) { false }
+      expect(Spree::Chimpy).to receive(:create_segment)
+
+      Spree::Chimpy.ensure_segment
+    end
+  end
+
   def config(options = {})
     config = Spree::Chimpy::Configuration.new
     config.key        = options[:key]

--- a/spec/lib/list_interface_spec.rb
+++ b/spec/lib/list_interface_spec.rb
@@ -4,7 +4,7 @@ describe Spree::Chimpy::Interface::List do
   let(:interface) { described_class.new('Members', 'customers', true, true, nil) }
   let(:api)       { double(:api) }
   let(:lists)     { double(:lists, :[] => [{"name" => "Members", "id" => "a3d3" }] ) }
-  let(:key)       { 'e025fd58df5b66ebd5a709d3fcf6e600-us8' }
+  let(:key)       { '857e2096b21e5eb385b9dce2add84434-us14' }
 
   before do
     Spree::Chimpy::Config.key = key
@@ -59,6 +59,7 @@ describe Spree::Chimpy::Interface::List do
   end
 
   it "segments users" do
+    Spree::Chimpy::Config.customer_segment_name = "customers"
     expect(lists).to receive(:subscribe).
       with('a3d3', {email: 'user@example.com'}, {'SIZE' => '10'},
             'html', true, true, true, true)
@@ -68,6 +69,7 @@ describe Spree::Chimpy::Interface::List do
   end
 
   it "segments" do
+    Spree::Chimpy::Config.customer_segment_name = "customers"
     expect(lists).to receive(:static_segments).with('a3d3').and_return([{"id" => '123', "name" => "customers"}])
     expect(lists).to receive(:static_segment_members_add).with('a3d3', 123, [{email: "test@test.nl"}, {email: "test@test.com"}])
     interface.segment(["test@test.nl", "test@test.com"])
@@ -88,5 +90,14 @@ describe Spree::Chimpy::Interface::List do
   it "adds a merge var" do
     expect(lists).to receive(:merge_var_add).with("a3d3", "SIZE", "Your Size")
     interface.add_merge_var('SIZE', 'Your Size')
+  end
+
+  it "does not segment users when no segment provided" do
+    Spree::Chimpy::Config.customer_segment_name = ""
+    allow(lists).to receive(:subscribe)
+
+    expect(lists).to_not receive(:static_segment_members_add)
+
+    interface.subscribe("user@example.com", {'SIZE' => '10'}, {customer: true})
   end
 end

--- a/spec/lib/orders_interface_spec.rb
+++ b/spec/lib/orders_interface_spec.rb
@@ -4,7 +4,7 @@ describe Spree::Chimpy::Interface::Orders do
   let(:interface) { described_class.new }
   let(:api)       { double(:api) }
   let(:list)      { double() }
-  let(:key)       { 'e025fd58df5b66ebd5a709d3fcf6e600-us8' }
+  let(:key)       { '857e2096b21e5eb385b9dce2add84434-us14' }
 
   def create_order(options={})
     user  = create(:user, email: options[:email])

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Spree::Order do
-  let(:key) { 'e025fd58df5b66ebd5a709d3fcf6e600-us8' }
+  let(:key) { '857e2096b21e5eb385b9dce2add84434-us14' }
   let(:order) { create(:completed_order_with_totals) }
 
   it 'has a source' do


### PR DESCRIPTION
Simple configurable change to ignore the segment functionality whenever the segment is not configured so that the store can decide to operate a list without the segmentation.  Defaults to using the behavior since the default preference has a segment defined.
