### PR TITLE
bugfix: gibbon request init error

### DIFF
--- a/lib/spree_chimpy.rb
+++ b/lib/spree_chimpy.rb
@@ -30,7 +30,7 @@ module Spree::Chimpy
   end
 
   def api
-    Gibbon::Request.new({ api_key: Config.key }.merge(Config.api_options)) if configured?
+    Gibbon::Request.new(api_key: Config.key, timeout: Config.api_options[:timeout]) if configured?
   end
 
   def store_api_call


### PR DESCRIPTION
bugfix: gibbon/request.rb:7:in `initialize': unknown keyword: throws_exceptions (ArgumentError)
for stable-3