### PR TITLE
Improve user sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Makes it easy to integrate your [Spree][1] app with [MailChimp][2].
 > to sync up all your existing order data with mail chimp. Run this after
 > installing spree_chimpy to an existing store.
 
+> Also provides `rake spree_chimpy:users:sync_from_mailchimp` which annotates
+> your spree users as being subscribed or not, according to Mailchimp.
+
 **Deferred Processing**
 > Communication between Spree and MailChimp is synchronous by default. If you
 > have `delayed_job` in your bundle, the communication is queued up and

--- a/lib/tasks/spree_chimpy.rake
+++ b/lib/tasks/spree_chimpy.rake
@@ -46,27 +46,78 @@ namespace :spree_chimpy do
         puts "done"
       end
     end
-  end
 
-  desc 'sync all users with mailchimp'
-  task sync: :environment do
-    emails = Spree.user_class.pluck(:email)
-    puts "Syncing all users"
-    emails.each do |email|
-      response = Spree::Chimpy.list.info(email)
-      print '.'
+    desc "sync all users from mailchimp"
+    task sync_from_mailchimp: :environment do
+      puts "Syncing users with data from Mailchimp"
 
-      response["errors"].try :each do |error|
-        puts "Error #{error['error']["code"]} with email: #{error['email']["email"]} \n
-              msg: #{error["error"]}"
-      end
+      list = Spree::Chimpy.list
 
-      case response[:status]
-      when "subscribed"
-        Spree.user_class.where(email: email).update_all(subscribed: true)
-      when "unsubscribed"
-        Spree.user_class.where(email: email).update_all(subscribed: false)
+      emails_and_statuses = emails_and_statuses_for_list list
+
+      puts "Found #{emails_and_statuses.count} members to update."
+
+      grouped_emails = emails_and_statuses.group_by { |m| m["status"] }
+
+      {
+        "subscribed" => true,
+        "unsubscribed" => false,
+      }.each do |status, subscribed_db_value|
+        emails_to_update = grouped_emails[status].map { |m| m["email_address"] }
+        puts "Setting #{emails_to_update.count} emails to #{status}"
+        Spree.user_class.where(email: emails_to_update).
+          update_all(subscribed: subscribed_db_value)
       end
     end
+  end
+
+  # Iterate over list members, return a list of hashes with member information.
+  # returns: [
+  #   {"email_address" => "xxx@example.com", "status" => "subscribed"},
+  #   ..., ...,
+  # ]
+  def emails_and_statuses_for_list(list)
+    fields = %w(email_address members.status total_items)
+    # YMMV, but given we are fetching a small number of fields, this is likely
+    # safe.
+    chunk_size = 5_000
+
+    members = []
+    total_items = nil
+    list_params = { params: {
+      fields: fields.join(","),
+      count: chunk_size,
+      offset: 0,
+    } }
+
+    # make the first request, and continue to iterate until we have all
+    while total_items.nil? || members.count < total_items
+      # useful if you want to debug the pagination
+      # pp total_items, list_params
+
+      # safety check!
+      if total_items.present? && list_params[:params][:offset] > total_items
+        fail "Fencepost error, unable to fetch all members.  This may be due "\
+          "to changes in list size while iterating over it.  Please try "\
+          "again at a less busy time."
+      end
+      # execute the query
+      response = list.api_list_call.members.retrieve list_params
+      # capture the results of this chunk
+      members += response["members"]
+
+      # update pagination tracking
+      if total_items.nil?
+        total_items = response["total_items"]
+      elsif total_items != response["total_items"]
+        warn "Total items shifted during pagination.  To ensure compelte data "\
+          "you may want to re-run the script."
+      end
+
+      # update query parameters for next chunk
+      list_params[:params][:offset] += chunk_size
+    end
+
+    members
   end
 end


### PR DESCRIPTION
This PR attempts to improve the user performace from Mailchimp.  The
diff covers the following improvements:

 * **Speed**: instead of iterating through Spree users one by one and
looking them up in mailchimp, prefer to pull all subscription data in a
big batch from Mailchimp, and then update local db as needed.
 * **User-friendliness**: while I preserved exact functionality, I
renamed/scoped the task to more clearly reflect the directionality of
this sync.  In particular, based on comments and lack of documentation,
it was unclear what this task was actually doing.  Now we specify
explicitly in the README and code that we're pulling subscription status
from Mailchimp.