### PR TITLE
Update controller_filters.rb

### DIFF
--- a/lib/spree/chimpy/controller_filters.rb
+++ b/lib/spree/chimpy/controller_filters.rb
@@ -3,8 +3,8 @@ module Spree::Chimpy
     extend ActiveSupport::Concern
 
     included do
-      before_filter :set_mailchimp_params
-      before_filter :find_mail_chimp_params, if: :mailchimp_params?
+      before_action :set_mailchimp_params
+      before_action :find_mail_chimp_params, if: :mailchimp_params?
       include ::Spree::Core::ControllerHelpers::Order
     end
 


### PR DESCRIPTION
Can this fix be added to 3-stable branch also? 
I'm getting  this when trying to run it on my spree 3.5 application
```
undefined method `before_filter' for Spree::StoreController:Class (NoMethodError)
Did you mean?  before_action
```